### PR TITLE
ensure the swagger spec is valid JSON

### DIFF
--- a/check_swagger/main.py
+++ b/check_swagger/main.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import argparse
 import codecs
+import json
 import sys
 from fnmatch import fnmatch
 
@@ -27,6 +28,8 @@ def main():
                 spec = yaml.safe_load(f)
                 if not isinstance(spec, dict):
                     raise SwaggerValidationError('root node is not a mapping')
+                # ensure the spec is valid JSON
+                spec = json.loads(json.dumps(spec))
                 validator = swagger_spec_validator.util.get_validator(spec, url)
                 validator.validate_spec(spec, url)
         except yaml.YAMLError as exc:


### PR DESCRIPTION
when loading from yaml, object keys are not necessarily strings,
which is problematic JSON Schema validation because JSON only allows
object keys to be strings

a round-trip serialization to and from JSON will coerce compatible
types to be valid JSON

fixes #2 